### PR TITLE
added a retry for 500 internal service error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "4"
+  - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+sudo: false

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Usage:
 mws.Orders.ListOrders({
   MarketplaceId: 'lel',
   MaxResultsPerPage: 10,
-  CreatedAfter: new Date(1,1,2015),
-  CreatedBefore: new Date(1,2,2015)
+  CreatedAfter: new Date(2015, 1, 1),
+  CreatedBefore: new Date(2015, 1, 2)
 })
 .then(({ result, metadata }) => {
   // result

--- a/lib/client.js
+++ b/lib/client.js
@@ -123,6 +123,25 @@ class AmazonMwsClient {
      * @return Promise
      */
     call(req, q, meta) {
+
+        const doRetry = (err) => {
+            if (!meta.retry) {
+                throw err;
+            }
+
+            const attempt = meta.attempt + 1;
+
+            if (attempt > meta.max_attempts) {
+                throw err;
+            }
+
+            // simple exponential backoff for dealing with throttling
+            const backoffDuration = Math.min(100 * Math.pow(2, attempt), meta.max_backoff);
+
+            return Promise.delay(backoffDuration)
+                .then(() => this.call(req, q, _.assign({}, meta, { attempt })));
+        };
+
         return this.request(req, q, meta).then((response) => {
             const body = response.body;
 
@@ -166,40 +185,9 @@ class AmazonMwsClient {
                           metadata: _.concat(metadata, nextData.metadata)
                       }));
                 })
-                .catch({ code: 'RequestThrottled' }, (err) => {
-                    if (!meta.retry) {
-                        throw err;
-                    }
-
-                    const attempt = meta.attempt + 1;
-
-                    if (attempt > meta.max_attempts) {
-                        throw err;
-                    }
-
-                    // simple exponential backoff for dealing with throttling
-                    const backoffDuration = Math.min(100 * Math.pow(2, attempt), meta.max_backoff);
-
-                    return Promise.delay(backoffDuration)
-                        .then(() => this.call(req, q, _.assign({}, meta, { attempt })));
-                })
-                .catch({ code: 'QuotaExceeded' }, (err) => {
-                    if (!meta.retry) {
-                        throw err;
-                    }
-
-                    const attempt = meta.attempt + 1;
-
-                    if (attempt > meta.max_attempts) {
-                        throw err;
-                    }
-
-                    // simple exponential backoff for dealing with throttling
-                    const backoffDuration = Math.min(100 * Math.pow(2, attempt), meta.max_backoff);
-
-                    return Promise.delay(backoffDuration)
-                        .then(() => this.call(req, q, _.assign({}, meta, { attempt })));
-                });
+                .catch({ code: 'InternalError' }, doRetry)
+                .catch({ code: 'RequestThrottled' }, doRetry)
+                .catch({ code: 'QuotaExceeded' }, doRetry);
         });
     }
 


### PR DESCRIPTION
According to the [Handling Error](https://docs.developer.amazonservices.com/en_DE/dev_guide/DG_Errors.html) section of the MWS documentation:

> The common response to a 500 or 503 service error is to try the request again. Such service errors are usually only temporary and will resolve themselves. If you want to retry an operation call after receiving a 500 or 503 error, you can immediately retry after the first error response.

We recently encountered a lot of 500 errors using the module, so I thought after I added this to my fork, I should contribute back.

Also fixed the Travis CI so it stops yelling at build errors. Also made sure the documentation in `README` conforms to the correct `Date` signature.